### PR TITLE
ESP32 WiFi & Changed Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported communication modules:
 - Bluetooth: HC-05, HC-06, HM-10 or compatible; BT Classic and BLE on ESP32
 - WiFi ESP8266;
 - Ethernet Shield W5100;
+- WiFi ESP32;
 
 Supported mobile OS:
 - Android;

--- a/RemoteXY.h
+++ b/RemoteXY.h
@@ -34,6 +34,7 @@
     #define	REMOTEXY_MODE__ESP32_BT
     #define	REMOTEXY_MODE__ESP32_BLE
 	#define REMOTEXY_MODE__ESP32WIFI_LIB
+	#define REMOTEXY_MODE__ESP32WIFI_LIB_POINT
 
    Parameters depending on the selected mode (for example):
     #define REMOTEXY_SERIAL Serial  // for Hardware Serial
@@ -68,7 +69,8 @@
      - Fixed a bug where the length of all input variables more than 256;
      - Fixed a bug where millis() overflow in 50 days;
      - Fixed some bugs;
-          
+   version 2.3.5
+     - Support for ESP32 WiFi       
 */
 
 #ifndef _REMOTEXY_H_
@@ -128,6 +130,9 @@
   #define REMOTEXY_MOD__ESP32_BLE_LIB
 #elif defined(REMOTEXY_MODE__ESP32WIFI_LIB)
   #define REMOTEXY_MOD__ESP32WIFI_LIB  
+#elif defined(REMOTEXY_MODE__ESP32WIFI_LIB_POINT) || defined(REMOTEXY_MODE__ESP32WIFIPOINT_LIB)
+  #define REMOTEXY_MOD__ESP32WIFI_LIB
+  #define REMOTEXY_WIFI__POINT
 #else
   #error RemoteXY mode does not defined or defined error: REMOTEXY_MODE__XXXXXXX 
 #endif

--- a/RemoteXY.h
+++ b/RemoteXY.h
@@ -33,6 +33,7 @@
    Only ESP32 boards:
     #define	REMOTEXY_MODE__ESP32_BT
     #define	REMOTEXY_MODE__ESP32_BLE
+	#define REMOTEXY_MODE__ESP32WIFI_LIB
 
    Parameters depending on the selected mode (for example):
     #define REMOTEXY_SERIAL Serial  // for Hardware Serial
@@ -125,6 +126,8 @@
   #define REMOTEXY_CLOUD
 #elif defined(REMOTEXY_MODE__ESP32_BLE)
   #define REMOTEXY_MOD__ESP32_BLE_LIB
+#elif defined(REMOTEXY_MODE__ESP32WIFI_LIB)
+  #define REMOTEXY_MOD__ESP32WIFI_LIB  
 #else
   #error RemoteXY mode does not defined or defined error: REMOTEXY_MODE__XXXXXXX 
 #endif
@@ -157,7 +160,9 @@
 #elif defined(REMOTEXY_MOD__ESP8266WIFI_LIB_CLOUD)
   #include "modules/esp8266wifi_cloud.h" 
 #elif defined(REMOTEXY_MOD__ESP32_BLE_LIB)
-  #include "modules/esp32_ble.h" 
+  #include "modules/esp32_ble.h"
+#elif defined(REMOTEXY_MOD__ESP32WIFI_LIB)
+  #include "modules/esp32wifi.h"   
 #endif 
 
 #ifndef REMOTEXY_ACCESS_PASSWORD 

--- a/RemoteXY.h
+++ b/RemoteXY.h
@@ -54,6 +54,9 @@
    Debug log info on 115200 (define before include this library):
     #define REMOTEXY__DEBUGLOGS Serial
 
+   Flag to indicate when something has been changed (define before include this library):
+  	#define REMOTEXY_CHANGED_FLAG
+
    = Version history ========================================
 
    version 2.2.5   
@@ -70,7 +73,8 @@
      - Fixed a bug where millis() overflow in 50 days;
      - Fixed some bugs;
    version 2.3.5
-     - Support for ESP32 WiFi       
+     - Support for ESP32 WiFi;
+	 - Support for changed_flag;       
 */
 
 #ifndef _REMOTEXY_H_

--- a/classes/RemoteXY_API.h
+++ b/classes/RemoteXY_API.h
@@ -27,7 +27,7 @@ class CRemoteXY_API {
   uint16_t inputLength;
   uint16_t confLength;
   uint8_t *connect_flag;
-
+  uint8_t *changed_flag;	// Flag to indicate when input variables have changed
   uint8_t *receiveBuffer;
   uint16_t receiveBufferLength;
   uint16_t receiveIndex;
@@ -70,7 +70,10 @@ class CRemoteXY_API {
     uint16_t varLength = outputLength+inputLength;
     connect_flag = var+varLength;
     *connect_flag = 0;   
-        
+    
+	changed_flag = var+varLength+1;
+	*changed_flag = 0;
+	    
     accessPassword = (uint8_t*)_accessPassword;
 
     receiveBufferLength=inputLength;
@@ -246,14 +249,14 @@ class CRemoteXY_API {
       p++;
     }        
     receiveIndex=0;
-  }  
-  
-  uint8_t handleReceivePackage () {
+  }
+    
+uint8_t handleReceivePackage () {
     uint8_t command;
     uint16_t i;
     uint16_t length;
     uint8_t *p, *kp;
-       
+	   
     length = receiveBuffer[1]|(receiveBuffer[2]>>8); 
     length-=6;
     command = receiveBuffer[3];
@@ -298,8 +301,15 @@ class CRemoteXY_API {
           p=receiveBuffer+4;
           kp=var;
           i= inputLength;
-          while (i--) *kp++=*p++;
-        }
+          while (i--) 
+		  {
+			if (*kp != *p)
+			{
+			  *kp++=*p++;
+			  *changed_flag = 1;
+			}
+		  }
+		}
         sendPackage (command, 0, 0, 0);
         break;   
       case 0xC0:  

--- a/classes/RemoteXY_API.h
+++ b/classes/RemoteXY_API.h
@@ -27,7 +27,9 @@ class CRemoteXY_API {
   uint16_t inputLength;
   uint16_t confLength;
   uint8_t *connect_flag;
-  uint8_t *changed_flag;	// Flag to indicate when input variables have changed
+#ifdef REMOTEXY_CHANGED_FLAG  
+  uint8_t *changed_flag;	// Pointer to flag to indicate when input variables have changed
+#endif  
   uint8_t *receiveBuffer;
   uint16_t receiveBufferLength;
   uint16_t receiveIndex;
@@ -43,8 +45,8 @@ class CRemoteXY_API {
   virtual void closeConnection () {};
   virtual void sendStart (uint16_t len) {};
   virtual void sendByte (uint8_t b) {};
-  virtual uint8_t receiveByte () {};
-  virtual uint8_t availableByte () {};  
+  virtual uint8_t receiveByte () {return 0;};
+  virtual uint8_t availableByte () {return 0;};
   
   public:
   void init (const void * _conf, void * _var, const char * _accessPassword) {
@@ -70,10 +72,10 @@ class CRemoteXY_API {
     uint16_t varLength = outputLength+inputLength;
     connect_flag = var+varLength;
     *connect_flag = 0;   
-    
+#ifdef REMOTEXY_CHANGED_FLAG    
 	changed_flag = var+varLength+1;
 	*changed_flag = 0;
-	    
+#endif	    
     accessPassword = (uint8_t*)_accessPassword;
 
     receiveBufferLength=inputLength;
@@ -303,11 +305,21 @@ uint8_t handleReceivePackage () {
           i= inputLength;
           while (i--) 
 		  {
+#ifdef REMOTEXY_CHANGED_FLAG
 			if (*kp != *p)
 			{
+			  // Byte has been changed	
 			  *kp++=*p++;
 			  *changed_flag = 1;
 			}
+			else
+			{
+			  kp++;
+			  p++;
+			}
+#else
+			*kp++=*p++;
+#endif
 		  }
 		}
         sendPackage (command, 0, 0, 0);

--- a/examples/WiFiPoint/WiFiPoint_ESP32/WiFiPoint_ESP32.pde
+++ b/examples/WiFiPoint/WiFiPoint_ESP32/WiFiPoint_ESP32.pde
@@ -1,0 +1,94 @@
+/*
+  RemoteXY example. 
+  Smartphone connect over Wi-Fi access point from ESP32 
+
+  This shows an example of using the library RemoteXY.
+  In the example you can control an LED e.g. on ESP_IO32 using the button on the 
+  smartphone.
+  
+  Download the mobile app from the 
+  website: http://remotexy.com/download/ for connect this sketch.
+  
+  Use the website http://remotexy.com/ to create your own management 
+  interface your arduino with your smartphone or tablet.
+  You can create different management interfaces. Use buttons, 
+  switches, sliders, joysticks (g-sensor) all colors and sizes 
+  in its interface. Next, you will be able to get the sample 
+  code for arduino to use your interface for control from a 
+  smartphone or tablet. You will not need to re-install the 
+  android app, as it will determine which interface you have 
+  downloaded the arduino.
+  
+*/
+
+///////////////////////////////////////////// 
+//        RemoteXY include library         // 
+///////////////////////////////////////////// 
+
+/* RemoteXY select connection mode and include library */ 
+#define REMOTEXY_MODE__ESP32WIFI_LIB_POINT
+#define REMOTEXY_CHANGED_FLAG
+#include <WiFi.h>
+#include <RemoteXY.h> 
+
+/* RemoteXY connection settings */ 
+
+#define REMOTEXY_WIFI_SSID "RemoteXY" 
+#define REMOTEXY_WIFI_PASSWORD "12345678"
+#define REMOTEXY_SERVER_PORT 6377
+
+/* RemoteXY configurate  */ 
+unsigned char RemoteXY_CONF[] = 
+  { 1,0,11,0,1,5,1,0,21,2
+  ,59,59,2,88,0 }; 
+   
+/* this structure defines all the variables of your control interface */ 
+struct { 
+
+    /* input variable */
+  unsigned char button_1; /* =1 if button pressed, else =0 */
+
+    /* other variable */
+  unsigned char connect_flag;  /* =1 if wire connected, else =0 */
+#ifdef REMOTEXY_CHANGED_FLAG
+  unsigned char changed_flag;  /* =1 if any variable has changed, else =0 */
+#endif  
+} RemoteXY; 
+
+///////////////////////////////////////////// 
+//           END RemoteXY include          // 
+///////////////////////////////////////////// 
+
+#define PIN_BUTTON_1 32
+
+
+void setup()  
+{ 
+  RemoteXY_Init ();  
+   
+  pinMode (PIN_BUTTON_1, OUTPUT);
+   
+
+  // TODO your setup code 
+   
+} 
+
+void loop()  
+{  
+  RemoteXY_Handler (); 
+
+#ifdef REMOTEXY_CHANGE_FLAG  
+  if (RemoteXY.changed_flag)
+  { 
+    // This code is only executed if one or more of the RemoteXY variables have been changed  
+	RemoteXY.changed_flag = 0;	// Clear the flag ready for the next time the RemoteXY_Handler is called.
+    digitalWrite(PIN_BUTTON_1, (RemoteXY.button_1==0)?LOW:HIGH);
+  }
+#else
+  digitalWrite(PIN_BUTTON_1, (RemoteXY.button_1==0)?LOW:HIGH);
+#endif
+
+  // TODO your loop code 
+  // use the RemoteXY structure for data transfer 
+
+}

--- a/modules/esp32wifi.h
+++ b/modules/esp32wifi.h
@@ -157,6 +157,7 @@ class CRemoteXY : public CRemoteXY_API {
         return b;
       }
     }
+	return 0;
   }
   
   uint8_t availableByte () {   

--- a/modules/esp32wifi.h
+++ b/modules/esp32wifi.h
@@ -1,0 +1,183 @@
+#ifndef _REMOTEXY_MOD_ESP32WIFI_H_
+#define _REMOTEXY_MOD_ESP32WIFI_H_
+
+/*
+for ESP32 board;
+need include <WiFi.h>;
+*/
+
+#include "classes/RemoteXY_API.h"
+
+#define REMOTEXY_SEND_BUFFER_LENGTH 256
+
+class CRemoteXY : public CRemoteXY_API {
+
+  protected:
+  uint16_t port;
+  char * wifiSsid;
+  char * wifiPassword;
+  
+  WiFiServer *server;
+  WiFiClient client; 
+  
+  uint8_t wifiStatus;
+  uint32_t serverTimeOut;
+  
+  uint8_t sendBuffer[REMOTEXY_SEND_BUFFER_LENGTH];
+  uint16_t sendBufferCount; 
+  uint16_t sendBytesAvailable;  
+
+  public:
+  CRemoteXY (const void * _conf, void * _var, const char * _accessPassword, const char * _wifiSsid, const char * _wifiPassword, uint16_t _port) {
+    port = _port;
+    wifiSsid = (char *) _wifiSsid;
+    wifiPassword = (char *) _wifiPassword;
+    serverTimeOut = 0;
+    init (_conf, _var, _accessPassword);    
+  }
+  
+  uint8_t initModule () {  
+    delay(100);
+    WiFi.disconnect();
+    WiFi.softAPdisconnect(true);
+#if defined(REMOTEXY_WIFI__POINT)
+    /* access point */
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(wifiSsid, wifiPassword);
+#if defined(REMOTEXY__DEBUGLOGS)
+    REMOTEXY__DEBUGLOGS.println();
+    REMOTEXY__DEBUGLOGS.print("IP: ");
+    REMOTEXY__DEBUGLOGS.println(WiFi.softAPIP());
+#endif
+#else    
+    /* station */
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(wifiSsid, wifiPassword);
+    delay(1000);
+    
+#if defined(REMOTEXY__DEBUGLOGS)
+    REMOTEXY__DEBUGLOGS.println();
+    REMOTEXY__DEBUGLOGS.println("Start connecting to access point...");
+#endif    
+#endif
+    client.stop();
+    server = new WiFiServer (port);
+    server->begin();    
+    server->setNoDelay(true);
+#if defined(REMOTEXY__DEBUGLOGS)
+    REMOTEXY__DEBUGLOGS.println("Server started");
+#endif
+    return 1;
+  }
+
+  void handlerModule () {
+    uint8_t status = WiFi.status();
+    if (status != wifiStatus) {
+      wifiStatus = status;
+#if defined(REMOTEXY__DEBUGLOGS)
+      if (wifiStatus == WL_CONNECTED) {
+        REMOTEXY__DEBUGLOGS.println();
+        REMOTEXY__DEBUGLOGS.println("Connected to access point");
+        REMOTEXY__DEBUGLOGS.print("IP: ");
+        REMOTEXY__DEBUGLOGS.println(WiFi.localIP());
+        REMOTEXY__DEBUGLOGS.print ("<-");
+      }
+#endif  
+    }
+    
+    if (!client) {
+      client=server->available();
+      if (client) {
+        resetServerTimeOut ();  // new client
+#if defined(REMOTEXY__DEBUGLOGS)
+        REMOTEXY__DEBUGLOGS.println ();
+        REMOTEXY__DEBUGLOGS.println ("Client connected");
+        REMOTEXY__DEBUGLOGS.print ("<-");
+#endif
+      }
+    }
+    if (client) {
+      if (client.connected()) {
+        if (millis () - serverTimeOut > REMOTEXY_SERVER_TIMEOUT) {
+          client.stop ();
+#if defined(REMOTEXY__DEBUGLOGS)
+          REMOTEXY__DEBUGLOGS.println ();
+          REMOTEXY__DEBUGLOGS.println ("Client stoped by timeout");
+          REMOTEXY__DEBUGLOGS.print ("<-");
+#endif
+        }
+      }
+      else {
+        client.stop ();
+#if defined(REMOTEXY__DEBUGLOGS)
+        REMOTEXY__DEBUGLOGS.println ();
+        REMOTEXY__DEBUGLOGS.println ("Client stoped");
+        REMOTEXY__DEBUGLOGS.print ("<-");
+#endif
+      }
+    }        
+  }
+
+
+  void sendStart (uint16_t len) {
+    sendBytesAvailable = len;
+    sendBufferCount = 0;
+  }
+
+  void sendByte (uint8_t b) {
+    if (client) {
+      if (client.connected()) {
+#if defined(REMOTEXY__DEBUGLOGS)
+        REMOTEXY__DEBUGLOGS.print (b, HEX);
+        REMOTEXY__DEBUGLOGS.print (' ');
+#endif
+        sendBuffer[sendBufferCount++] = b;
+        sendBytesAvailable--;       
+        if ((sendBufferCount==REMOTEXY_SEND_BUFFER_LENGTH) || (sendBytesAvailable==0)) {
+          uint8_t buf[sendBufferCount];
+          for (uint16_t i=0; i<sendBufferCount; i++) buf[i]=sendBuffer[i];
+          client.write(buf, sendBufferCount);
+          sendBufferCount=0;
+          resetServerTimeOut ();
+        } 
+      }
+    }
+  }  
+  
+  uint8_t receiveByte () {
+    uint8_t b;
+    if (client) {
+      if (client.connected()) {
+        b = client.read();
+#if defined(REMOTEXY__DEBUGLOGS)
+        REMOTEXY__DEBUGLOGS.print (b, HEX);
+        REMOTEXY__DEBUGLOGS.print (' ');
+#endif
+        resetServerTimeOut ();
+        return b;
+      }
+    }
+  }
+  
+  uint8_t availableByte () {   
+#if !defined(REMOTEXY_WIFI__POINT)
+    if (wifiStatus != WL_CONNECTED) return 0;
+#endif
+    if (client) {
+      if (client.connected()) return client.available();
+    }
+    return 0;
+  }  
+  
+  void resetServerTimeOut () {
+    serverTimeOut = millis (); //REMOTEXY_SERVER_TIMEOUT;
+  }
+
+};
+
+
+#define RemoteXY_Init() remotexy = new CRemoteXY (RemoteXY_CONF_PROGMEM, &RemoteXY, REMOTEXY_ACCESS_PASSWORD, REMOTEXY_WIFI_SSID, REMOTEXY_WIFI_PASSWORD, REMOTEXY_SERVER_PORT)
+
+
+
+#endif //_REMOTEXY_MOD_ESP32WIFI_H_


### PR DESCRIPTION
Added option to use ESP32 in WiFi mode (based on ESP8266), including a new example sketch.
Tested with an ESP-WROOM32 module.

Also added the ability to include a changed_flag at the end of the variable structure which RemoteXY can then set to 1 when it has updated any of the variables.  Hence you only need to look for and make use of changes if this is set after calling the RemoteXY_Handler().